### PR TITLE
Include unreferenced fields in doc generation

### DIFF
--- a/api/Main.hx
+++ b/api/Main.hx
@@ -2,5 +2,6 @@ package ;
 class Main {
 	public static inline var projectName = 'untitled';
 	public static inline var projectPackage = 'arm';
+	public static inline var projectVersion = '1.0.0';
 	public static function main() {}
 }

--- a/api/api.hxml
+++ b/api/api.hxml
@@ -56,5 +56,7 @@
 -D kha
 -D kha_version=1810
 -D kha_project_name=untitled
+--no-output
+-dce no
 -js krom\krom.js
 -main Main


### PR DESCRIPTION
The api docs are missing fields not referenced anywhere (which skips a lot in haxe std).  
Fixed by disabling dead-code-elimination.
