### PR TITLE
Add gh actions workflow to build api docs to gh-pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: krdlab/setup-haxe@v1
+        with:
+          haxe-version: 4.2.2
+      - name: Setup
+        run: haxelib install dox
+      - name: Build documentation
+        run: |
+          cd api
+          haxe api.hxml -xml build/api.xml -D doc-gen
+          haxe dox.hxml
+      - name: Deploy gh-pages
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: api/pages

--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -1,7 +1,9 @@
-name: CI
+name: deploy-api-docs
 
-on: [push, pull_request]
-
+on:  
+  push:
+    tags:
+      - '*'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,3 +21,8 @@ jobs:
           cd api
           haxe api.hxml -xml build/api.xml -D doc-gen
           haxe dox.hxml
+      - name: Deploy gh-pages
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: api/pages


### PR DESCRIPTION
Like:
https://github.com/tong/armsdk/actions
→
https://tong.github.io/armsdk/

… to never have have outdated docs again.
