### PR TITLE
Add manual build trigger

### DIFF
--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
+    inputs:
+      haxe-version:
+        description: 'Haxe version to use'
+        required: true
+        default: 4.2.3
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,7 +20,7 @@ jobs:
           submodules: recursive
       - uses: krdlab/setup-haxe@v1
         with:
-          haxe-version: 4.2.2
+          haxe-version: ${{ github.event.inputs.haxe-version }}
       - name: Setup
         run: haxelib install dox
       - name: Build documentation


### PR DESCRIPTION
Added a manual trigger to the docs build/deploy workflow.
I don't think we really need this since the api docs build automatically if a new tag is created, but for rare cases (like currently) where you want to force docs deployment without waiting for a new tag.

The trigger button will show up when merged into master (https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/).

Also, it allows to manually specify the haxe version to use, which i've shamelessly set to the actual version (v4.2.3) as defaultt, in hope we see an update soon (v4.1.3 was released a year ago).