### PR TITLE
Fix API generation

### DIFF
--- a/api/dox.hxml
+++ b/api/dox.hxml
@@ -1,1 +1,1 @@
--cmd haxelib run dox -i build -o pages --title 'Armory 3D Engine' -D themeColor 0xcf2b43 -D textColor 0xffffff -D website 'https://armory3d.org/' -D logo 'https://avatars.githubusercontent.com/u/20436620?s=48'
+-cmd haxelib run dox -i build -o pages --title "Armory 3D Engine" -D themeColor 0xcf2b43 -D textColor 0xffffff -D website "https://armory3d.org/" -D logo "https://avatars.githubusercontent.com/u/20436620?s=48"


### PR DESCRIPTION
I'm not sure if this is a Windows thing, but dox wasn't happy with `'` used as quotation marks in dox.hxml.

Btw, is it possible to update armory3d.org/api when the (broken again) CI has run? It deploys the API docs, but seemingly only to gh-pages.