### PR TITLE
Fix doc generation

### DIFF
--- a/api/krom-resources/files.json
+++ b/api/krom-resources/files.json
@@ -5,6 +5,9 @@
 			"files": [
 				"painter-colored.frag.d3d11"
 			],
+			"file_sizes": [
+				1
+			],
 			"type": "shader",
 			"inputs": [
 				{
@@ -25,6 +28,9 @@
 			"name": "painter_colored_vert",
 			"files": [
 				"painter-colored.vert.d3d11"
+			],
+			"file_sizes": [
+				1
 			],
 			"type": "shader",
 			"inputs": [
@@ -86,6 +92,9 @@
 			"files": [
 				"painter-image.frag.d3d11"
 			],
+			"file_sizes": [
+				1
+			],
 			"type": "shader",
 			"inputs": [
 				{
@@ -115,6 +124,9 @@
 			"name": "painter_image_vert",
 			"files": [
 				"painter-image.vert.d3d11"
+			],
+			"file_sizes": [
+				1
 			],
 			"type": "shader",
 			"inputs": [
@@ -184,6 +196,9 @@
 			"files": [
 				"painter-text.frag.d3d11"
 			],
+			"file_sizes": [
+				1
+			],
 			"type": "shader",
 			"inputs": [
 				{
@@ -213,6 +228,9 @@
 			"name": "painter_text_vert",
 			"files": [
 				"painter-text.vert.d3d11"
+			],
+			"file_sizes": [
+				1
 			],
 			"type": "shader",
 			"inputs": [
@@ -282,6 +300,9 @@
 			"files": [
 				"painter-video.frag.d3d11"
 			],
+			"file_sizes": [
+				1
+			],
 			"type": "shader",
 			"inputs": [
 				{
@@ -311,6 +332,9 @@
 			"name": "painter_video_vert",
 			"files": [
 				"painter-video.vert.d3d11"
+			],
+			"file_sizes": [
+				1
 			],
 			"type": "shader",
 			"inputs": [


### PR DESCRIPTION
kha/internal/AssetsBuilder.hx complains without the `file_sizes` fields in files.json