### PR TITLE
Fix workflow doc generation

### DIFF
--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -5,11 +5,6 @@ on:
     tags:
       - '*'
   workflow_dispatch:
-    inputs:
-      haxe-version:
-        description: 'Haxe version to use'
-        required: true
-        default: 4.2.3
 
 jobs:
   build:
@@ -19,8 +14,6 @@ jobs:
         with:
           submodules: recursive
       - uses: krdlab/setup-haxe@v1
-        with:
-          haxe-version: ${{ github.event.inputs.haxe-version }}
       - name: Setup
         run: haxelib install dox
       - name: Build documentation
@@ -29,7 +22,7 @@ jobs:
           haxe api.hxml -xml build/api.xml -D doc-gen
           haxe dox.hxml
       - name: Deploy gh-pages
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           branch: gh-pages
           folder: api/pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: test
 
 on: [push, pull_request]
 
@@ -10,12 +10,7 @@ jobs:
         with:
           submodules: recursive
       - uses: krdlab/setup-haxe@v1
-        with:
-          haxe-version: 4.2.2
-      - name: Setup
-        run: haxelib install dox
-      - name: Build documentation
+      - name: Build api.xml
         run: |
           cd api
           haxe api.hxml -xml build/api.xml -D doc-gen
-          haxe dox.hxml

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,3 +1,4 @@
 build/
 krom/
 pages/
+api.xml


### PR DESCRIPTION
- Rename ci.yml to test.yml as this is what it's doing
- Remove docs generation from test workflow
- Remove the haxe-version input from the manual deploy-docs workflow
This fixes the workflow when triggered by push:tags.
Also it ensures that the same haxe version is used in both workflows.