### PR TITLE
[Critical] Fix Armory installation for Windows users without symlink privilege

### DIFF
--- a/armory.py
+++ b/armory.py
@@ -555,7 +555,17 @@ def update_armory_py(sdk_path, force_relink=False):
         # We can safely replace armory.py because Python is
         # operating on a cached armory.py module
         arm_module_file.unlink(missing_ok=True)
-        arm_module_file.symlink_to(Path(sdk_path) / 'armory.py')
+        try:
+            arm_module_file.symlink_to(Path(sdk_path) / 'armory.py')
+        except OSError as err:
+            if hasattr(err, 'winerror'):
+                if err.winerror == 1314:  # ERROR_PRIVILEGE_NOT_HELD
+                    # Manually copy the file to "simulate" symlink
+                    shutil.copy(Path(sdk_path) / 'armory.py', arm_module_file)
+                else:
+                    raise err
+            else:
+                raise err
 
 
 def start_armory(sdk_path: str):


### PR DESCRIPTION
For non-admin Windows users or users without dev mode enabled, it could happen that they have no privileges to create symlinks, leading to errors when registering Armory. Because the armory.py file must be deleted before creating the symlink, this leads to an corrupted installation, so this fix is quite critical. @luboslenco If possible, could you please upload a new build to itch.io after this is fixed?

Thanks to the Discord user Jefferson.moreira for reporting this :)