### PR TITLE
Reload SDK when SDK source type has changed

### DIFF
--- a/armory.py
+++ b/armory.py
@@ -667,7 +667,7 @@ def start_armory(sdk_path: str):
         import importlib
         start = importlib.reload(start)
 
-    use_local_sdk = os.path.exists(os.path.join(get_fp(), 'armsdk'))
+    use_local_sdk = (sdk_source == SDKSource.LOCAL)
     start.register(local_sdk=use_local_sdk)
 
     last_sdk_path = sdk_path
@@ -690,6 +690,7 @@ def stop_armory():
 
 
 def restart_armory(context):
+    old_sdk_source = sdk_source
     sdk_path = get_sdk_path(context)
 
     if sdk_path == "":
@@ -700,7 +701,7 @@ def restart_armory(context):
 
     # Only restart Armory when the SDK path changed or it isn't running,
     # otherwise we can keep the currently running instance
-    if not same_path(last_sdk_path, sdk_path) or not is_running:
+    if not same_path(last_sdk_path, sdk_path) or sdk_source != old_sdk_source or not is_running:
         stop_armory()
         assert not is_running
         start_armory(sdk_path)


### PR DESCRIPTION
If Blender was started with a CWD relative to an `armsdk` folder and that `armsdk` folder was at the same path than the SDK path set in the user preferences, subsequent loads of Blender files didn't result in an update of the `local_sdk` variable that is passed to Armory upon startup/restart. This would then cause havoc later.

To correctly update that variable, the SDK is now also reloaded in case the type of SDK source (env var, local, prefs) changes. Ideally the `local_sdk` variable should get removed completely in its current form and the `utils.get_sdk_path()` function should get refactored, it currently still uses code from a time where the SDK could come bundled with Blender.

Thanks to the Discord user wuaieyo for report :)