### PR TITLE
Relocate Armory addon to "Game Engine" category

### DIFF
--- a/armory.py
+++ b/armory.py
@@ -2,7 +2,7 @@
 # https://github.com/armory3d/armory
 bl_info = {
     "name": "Armory",
-    "category": "Render",
+    "category": "Game Engine",
     "location": "Properties -> Render -> Armory Player",
     "description": "3D Game Engine for Blender",
     "author": "Armory3D.org",


### PR DESCRIPTION
Currently the Armory3D addon is placed under the `Render` category:

![image](https://user-images.githubusercontent.com/69180012/160258146-edcc86c9-86d4-4f0d-8941-b2ac58f33f8e.png)

Since the addon is more game-development related it should be placed under the `Game Engine` category instead:

![image](https://user-images.githubusercontent.com/69180012/160258156-77aa09af-e8bb-44df-8b83-6315e71ae84d.png)