### PR TITLE
Support for Blender 3.3 LTS

### DIFF
--- a/armory.py
+++ b/armory.py
@@ -7,7 +7,7 @@ bl_info = {
     "description": "3D Game Engine for Blender",
     "author": "Armory3D.org",
     "version": (2022, 8, 0),
-    "blender": (2, 93, 0),
+    "blender": (3, 3, 0),
     "doc_url": "https://github.com/armory3d/armory/wiki",
     "tracker_url": "https://github.com/armory3d/armory/issues"
 }
@@ -296,9 +296,9 @@ class ArmoryAddonPreferences(AddonPreferences):
         layout.label(text="Welcome to Armory!")
 
         # Compare version Blender and Armory (major, minor)
-        if bpy.app.version[0] != 2 or bpy.app.version[1] != 93:
+        if bpy.app.version[0] != 3 or bpy.app.version[1] != 3:
             box = layout.box().column()
-            box.label(text="Warning: For Armory to work correctly, you need Blender 2.93 LTS.")
+            box.label(text="Warning: For Armory to work correctly, you need Blender 3.3 LTS.")
 
         layout.prop(self, "sdk_path")
         sdk_path = get_sdk_path(context)

--- a/armory.py
+++ b/armory.py
@@ -74,12 +74,9 @@ def detect_sdk_path():
     area = win.screen.areas[0]
     area_type = area.type
     area.type = "INFO"
-    override = bpy.context.copy()
-    override['window'] = win
-    override['screen'] = win.screen
-    override['area'] = win.screen.areas[0]
-    bpy.ops.info.select_all(override, action='SELECT')
-    bpy.ops.info.report_copy(override)
+    with bpy.context.temp_override(window=win, screen=win.screen, area=area):
+        bpy.ops.info.select_all(action='SELECT')
+        bpy.ops.info.report_copy()
     area.type = area_type
     clipboard = bpy.context.window_manager.clipboard
 


### PR DESCRIPTION
Link to https://github.com/armory3d/armory/pull/2565/.

- Changed the Blender version numbers
- Replaced some deprecated API functionality to override the bpy context for operator calls