### PR TITLE
Updater: add "Update Submodules" option

### DIFF
--- a/armory.py
+++ b/armory.py
@@ -328,7 +328,7 @@ class ArmoryAddonPreferences(AddonPreferences):
             row.operator("arm_addon.update", icon="FILE_REFRESH")
         else:
             row.operator("arm_addon.install", icon="IMPORT")
-        row.operator("arm_addon.restore")
+        row.operator("arm_addon.restore", icon="LOOP_BACK")
         if update_error_msg != '':
             col = box.column(align=True)
             col.scale_y = 0.8


### PR DESCRIPTION
In https://github.com/armory3d/armsdk/pull/46, the way the SDK was updated was slightly changed by no longer checking out the latest commits of individual submodules, but the commits referenced by the latest SDK. Now there is an option (enabled by default), with which the submodules are checked out to their latest versions after the SDK was updated:

![UI Screenshot](https://user-images.githubusercontent.com/17685000/188755432-3b37193b-f9f1-44a4-a6f2-83c3da649cf4.png)

Unfortunately my git version (2.27.0) had some errors I couldn't resolve when performing the updates (hours of stackoverflow, nothing seemed to work). Even though the SDK was freshly cloned, some submodules reported diverging branches even though no local changes existed, and others failed with "Fatal: Needed a single revision" for reasons I don't know. Krom even told me that the correct(!) remote didn't exist. After updating Git to a newer version, the errors would no longer happen (and they still happen with the old git installation that I still have installed), so I suspect it is some bug in Git itself.

To prevent these kinds of issues, there now is a check whether the user has a sufficiently new Git version. I tested the changes with two other git versions 2.34 and 2.37 and the issues did not occur. It's a bit unfortunate, but I didn't find any other solution.