### PR TITLE
Add option to automatically decide amount of Khamake processes

### DIFF
--- a/armory.py
+++ b/armory.py
@@ -171,7 +171,8 @@ class ArmoryAddonPreferences(AddonPreferences):
                  ('custom', "Custom", "Use a Custom Code Editor")],
         name="Code Editor", default='default', description='Use this editor for editing scripts')
     ui_scale: FloatProperty(name='UI Scale', description='Adjust UI scale for Armory tools', default=1.0, min=1.0, max=4.0)
-    khamake_threads: IntProperty(name='Khamake Threads', description='Allow Khamake to spawn multiple processes for faster builds', default=4, min=1)
+    khamake_threads: IntProperty(name='Khamake Processes', description='Allow Khamake to spawn multiple processes for faster builds', default=4, min=1)
+    khamake_threads_use_auto: BoolProperty(name='Auto', description='Let Khamake choose the number of processes automatically', default=False)
     compilation_server: BoolProperty(name='Compilation Server', description='Allow Haxe to create a local compilation server for faster builds', default=True)
     renderdoc_path: StringProperty(name="RenderDoc Path", description="Binary path", subtype="FILE_PATH", update=renderdoc_path_update, default="")
     ffmpeg_path: StringProperty(name="FFMPEG Path", description="Binary path", subtype="FILE_PATH", update=ffmpeg_path_update, default="")
@@ -377,7 +378,11 @@ class ArmoryAddonPreferences(AddonPreferences):
 
             elif self.tabs == "build":
                 box.label(text="Build Preferences")
-                box.prop(self, "khamake_threads")
+                row = box.split(factor=0.8, align=True)
+                _col = row.column(align=True)
+                _col.enabled = not self.khamake_threads_use_auto
+                _col.prop(self, "khamake_threads")
+                row.prop(self, "khamake_threads_use_auto", toggle=True)
                 box.prop(self, "compilation_server")
                 box.prop(self, "open_build_directory")
                 box.prop(self, "save_on_build")


### PR DESCRIPTION
Requires https://github.com/Kode/khamake/pull/262.

This PR adds an option to the user preferences that lets Khamake choose the number of processes automatically if enabled. It's off by default for now since I can only test it on my rather old 4 core computer where the auto setting defaults to 3 processes and is slightly slower than manually specifying more processes. If more tests are made by other users we can probably enable it by default.

![Screenshot](https://user-images.githubusercontent.com/17685000/192027919-2cc91a9a-7a25-443e-9c06-b0bd8765d1d6.png)

@luboslenco I'm wondering whether it's possible to move parts of the preferences out of the SDK into the armory submodule so that we no longer need all the `hasattr()` checks (see https://github.com/armory3d/armory/pull/2596) and we have less "separated" PRs. I'm not yet sure whether Blender allows to split the preferences into multiple files/classes while still saving them with one addon (we still need the SDK path setting to be in armory.py, for example), but if it turns out to be technically possible, what would you think of this?