### PR TITLE
Fixed long-standing permissions bug on Linux and macOS.

### DIFF
--- a/armory.py
+++ b/armory.py
@@ -477,6 +477,65 @@ def get_sdk_path(context: bpy.context) -> str:
     addon_prefs = preferences.addons["armory"].preferences
     return addon_prefs.sdk_path
 
+def apply_unix_permissions(sdk):
+    """Apply permissions to executable files in Linux and macOS
+
+    The .zip format does not preserve file permissions and will
+    cause every subprocess of Armory3D to not work at all. This
+    workaround fixes the issue so Armory releases will work.
+    """
+    if get_os() == 'linux':
+        paths=[
+            sdk + "/lib/armory_tools/cmft/cmft-linux64",
+            sdk + "/Krom/Krom",
+            # NodeJS
+            sdk + "/nodejs/node-linux32",
+            sdk + "/nodejs/node-linux64",
+            sdk + "/nodejs/node-linuxarm",
+            # Kha tools x64
+            sdk + "/Kha/Tools/linux_x64/haxe",
+            sdk + "/Kha/Tools/linux_x64/lame",
+            sdk + "/Kha/Tools/linux_x64/oggenc",
+            # Kha tools arm
+            sdk + "/Kha/Tools/linux_arm/haxe",
+            sdk + "/Kha/Tools/linux_arm/lame",
+            sdk + "/Kha/Tools/linux_arm/oggenc",
+            # Kha tools arm64
+            sdk + "/Kha/Tools/linux_arm64/haxe",
+            sdk + "/Kha/Tools/linux_arm64/lame",
+            sdk + "/Kha/Tools/linux_arm64/oggenc",
+            # Kinc tools x64
+            sdk + "/Kha/Kinc/Tools/linux_x64/kmake",
+            sdk + "/Kha/Kinc/Tools/linux_x64/kraffiti",
+            sdk + "/Kha/Kinc/Tools/linux_x64/krafix",
+            # Kinc tools arm
+            sdk + "/Kha/Kinc/Tools/linux_arm/kmake",
+            sdk + "/Kha/Kinc/Tools/linux_arm/kraffiti",
+            sdk + "/Kha/Kinc/Tools/linux_arm/krafix",
+            # Kinc tools arm64
+            sdk + "/Kha/Kinc/Tools/linux_arm64/kmake",
+            sdk + "/Kha/Kinc/Tools/linux_arm64/kraffiti",
+            sdk + "/Kha/Kinc/Tools/linux_arm64/krafix",
+        ]
+        for path in paths:
+            os.chmod(path, 0o777)
+
+    if get_os() == 'mac':
+        paths=[
+            sdk + "lib/armory_tools/cmft/cmft-osx",
+            sdk + "nodejs/node-osx",
+            sdk + "Krom/Krom.app/Contents/MacOS/Krom",
+            # Kha tools
+            sdk + "Kha/Tools/macos/haxe",
+            sdk + "Kha/Tools/macos/lame",
+            sdk + "Kha/Tools/macos/oggenc",
+            # Kinc tools
+            sdk + "Kha/Kinc/Tools/macos/kmake",
+            sdk + "Kha/Kinc/Tools/macos/kraffiti",
+            sdk + "Kha/Kinc/Tools/macos/krafix",
+        ]
+        for path in paths:
+            os.chmod(path, 0o777)
 
 def remove_readonly(func, path, excinfo):
     os.chmod(path, stat.S_IWRITE)
@@ -736,6 +795,8 @@ def start_armory(sdk_path: str):
               " Please make sure the SDK path is correct or that the SDK"
               " was downloaded correctly.")
         return
+
+    apply_unix_permissions(sdk_path)
 
     scripts_path = os.path.join(armory_path, "blender")
     sys.path.append(scripts_path)


### PR DESCRIPTION
Since Armory is a Blender addon that must be distributed through a .zip file, executable files will not work on macOS or Linux. This update adds code that automatically assigns the correct permissions every time the Armory addon is initialized. This allows users to simply install the addon on macOS and Linux and have it work. This has never been the case, and has always required extra setup on these platforms.

Unlike the last two pull requests, this one actually fixes the problem once and for all! The first time, untested code had issues on macOS. The second time, Xcode decided to undo all my work for some reason and I didn't notice until after I submitted the PR. This code is tested and working on macOS and Linux.