### PR TITLE
Add utility to print detailed version information to the console

### DIFF
--- a/armory.py
+++ b/armory.py
@@ -694,14 +694,12 @@ class ArmAddonPrintVersionInfoButton(bpy.types.Operator):
             print("==============================")
             print("| SDK: Modified files        |")
             print("==============================")
-            subprocess.check_call(["git", "diff", "--name-only"], cwd=sdk_path)  # Unstaged changes
-            subprocess.check_call(["git", "diff", "--name-only", "--cached"], cwd=sdk_path)  # Staged changes
+            subprocess.check_call(["git", "status", "--short"], cwd=sdk_path)
 
             print("==============================")
             print("| Submodules: Modified files |")
             print("==============================")
-            subprocess.check_call(["git", "submodule", "foreach", "--recursive", "git diff --name-only"], cwd=sdk_path)
-            subprocess.check_call(["git", "submodule", "foreach", "--recursive", "git diff --name-only --cached"], cwd=sdk_path)
+            subprocess.check_call(["git", "submodule", "foreach", "--recursive", "git status --short"], cwd=sdk_path)
 
             print("Done.")
 

--- a/armory.py
+++ b/armory.py
@@ -322,19 +322,29 @@ class ArmoryAddonPreferences(AddonPreferences):
                 row.label(text=f'Using local SDK from {sdk_path}')
             elif sdk_source == SDKSource.ENV_VAR:
                 row.label(text=f'Using SDK from "ARMSDK" environment variable: {sdk_path}')
+
         box = layout.box().column()
-        box.label(text="Armory SDK Manager")
+
+        row = box.row(align=True)
+        row.label(text="Armory SDK Manager")
+        col = row.column()
+        col.alignment = "RIGHT"
+        col.operator("arm_addon.help", icon="URL")
+
         box.label(text="Note: Development version may run unstable!")
+        box.separator()
 
         box.prop(self, "update_submodules")
+
         row = box.row(align=True)
         row.alignment = 'EXPAND'
-        row.operator("arm_addon.help", icon="URL")
+        row.operator("arm_addon.print_version_info", icon="INFO")
         if sdk_exists:
             row.operator("arm_addon.update", icon="FILE_REFRESH")
         else:
             row.operator("arm_addon.install", icon="IMPORT")
         row.operator("arm_addon.restore", icon="LOOP_BACK")
+
         if update_error_msg != '':
             col = box.column(align=True)
             col.scale_y = 0.8
@@ -656,6 +666,51 @@ def restore_repo(rootdir: str, subdir: str):
             return
 
 
+class ArmAddonPrintVersionInfoButton(bpy.types.Operator):
+    bl_idname = "arm_addon.print_version_info"
+    bl_label = "Print Version Info"
+    bl_description = "Print detailed information about the used SDK version to the console. This requires Git"
+
+    def execute(self, context):
+        sdk_path = get_sdk_path(context)
+        if sdk_path == "":
+            self.report({"ERROR"}, "Configure Armory SDK path first")
+            return {"CANCELLED"}
+
+        if not git_test(self):
+            return {"CANCELLED"}
+
+        def print_version_info():
+            print("==============================")
+            print("| SDK: Current commit        |")
+            print("==============================")
+            subprocess.check_call(["git", "branch", "-v"], cwd=sdk_path)
+
+            print("==============================")
+            print("| Submodules: Current commit |")
+            print("==============================")
+            subprocess.check_call(["git", "submodule", "status", "--recursive"], cwd=sdk_path)
+
+            print("==============================")
+            print("| SDK: Modified files        |")
+            print("==============================")
+            subprocess.check_call(["git", "diff", "--name-only"], cwd=sdk_path)  # Unstaged changes
+            subprocess.check_call(["git", "diff", "--name-only", "--cached"], cwd=sdk_path)  # Staged changes
+
+            print("==============================")
+            print("| Submodules: Modified files |")
+            print("==============================")
+            subprocess.check_call(["git", "submodule", "foreach", "--recursive", "git diff --name-only"], cwd=sdk_path)
+            subprocess.check_call(["git", "submodule", "foreach", "--recursive", "git diff --name-only --cached"], cwd=sdk_path)
+
+            print("Done.")
+
+        # Don't block UI
+        threading.Thread(target=print_version_info).start()
+
+        return {"FINISHED"}
+
+
 class ArmAddonInstallButton(bpy.types.Operator):
     """Download and set up Armory SDK"""
     bl_idname = "arm_addon.install"
@@ -861,6 +916,7 @@ def on_register_post():
 
 def register():
     bpy.utils.register_class(ArmoryAddonPreferences)
+    bpy.utils.register_class(ArmAddonPrintVersionInfoButton)
     bpy.utils.register_class(ArmAddonInstallButton)
     bpy.utils.register_class(ArmAddonUpdateButton)
     bpy.utils.register_class(ArmAddonRestoreButton)
@@ -875,6 +931,7 @@ def unregister():
     stop_armory()
     bpy.utils.unregister_class(ArmoryAddonPreferences)
     bpy.utils.unregister_class(ArmAddonInstallButton)
+    bpy.utils.unregister_class(ArmAddonPrintVersionInfoButton)
     bpy.utils.unregister_class(ArmAddonUpdateButton)
     bpy.utils.unregister_class(ArmAddonRestoreButton)
     bpy.utils.unregister_class(ArmAddonHelpButton)


### PR DESCRIPTION
When users report issues there currently is no easy way of getting important information about the used version and possible changes made to the SDK, so this PR adds a button to the addon preferences for printing this information to the console.

For example, the output may look like this:

```
Testing if git is working...
Git test succeeded.
==============================
| SDK: Current commit        |
==============================
  main               1a9f666 Update submodules
* print-version-info c72cfe9 Add utility to print detailed version information to the console
==============================
| Submodules: Current commit |
==============================
 bd1b7dee1dbf76b22c056768297669ffe707949c Kha (flash_is_ugly-392-gbd1b7dee)
 de8f5ea2926c7f43600cfbc1cb61130fb87b3169 Kha/Backends/Kinc-hxcpp/khacpp (remotes/origin/main)
 a164418c98b822f7a4222d7549f9917f1cd34f03 Kha/Kinc (heads/main)
 bc82de155473e989c68136194358c4787d85bb49 Kha/Kinc/Tools/freebsd_x64 (krafix_73be85e68d667408c05a928b1327e76e7b863b98-25-gbc82de1)
 d1ac847eb7fdc3fdddea4c101f9b7625f0080434 Kha/Kinc/Tools/linux_arm (krafix_73be85e68d667408c05a928b1327e76e7b863b98-26-gd1ac847)
 718e7330bea9156a1fd603dc2e0da82df1bc268a Kha/Kinc/Tools/linux_arm64 (krafix_73be85e68d667408c05a928b1327e76e7b863b98-25-g718e733)
 f629e45a39c9a508690e9f9a32118f1985ce9ab7 Kha/Kinc/Tools/linux_x64 (krafix_73be85e68d667408c05a928b1327e76e7b863b98-33-gf629e45)
 b2b5303b914c9431df5046e886565a4d0c4e36a8 Kha/Kinc/Tools/macos (krafix_73be85e68d667408c05a928b1327e76e7b863b98-36-gb2b5303)
+8f812163844b8dde52758ecbaf01aa15ef6dbcd0 Kha/Kinc/Tools/windows_x64 (krafix_73be85e68d667408c05a928b1327e76e7b863b98-26-g8f81216)
 bcc8e2ea2c30a2f97c12cd7697ef6158b9de8f6a Kha/Tools/freebsd_x64 (haxe_22ccc57cebff9945e94ea42e8b33bd6a4325e3e7)
 ba8765ec3266603c1aa6a9d2d7f704d9614a941a Kha/Tools/khamake (remotes/Kode/main-7-gba8765e)
 e1f80ceb0bd377ac1130ea5d6d10ec2018e3e9e7 Kha/Tools/linux_arm (haxe_22ccc57cebff9945e94ea42e8b33bd6a4325e3e7)
 90f0e0717f08ff5bd7883ccd55cb414b192efd68 Kha/Tools/linux_arm64 (haxe_22ccc57cebff9945e94ea42e8b33bd6a4325e3e7)
 61a4aa98d349895d1e36b879edff9a5472c162f6 Kha/Tools/linux_x64 (haxe_22ccc57cebff9945e94ea42e8b33bd6a4325e3e7)
 459700accdeda95ed9555b005ecb36ae809c6eff Kha/Tools/macos (haxe_22ccc57cebff9945e94ea42e8b33bd6a4325e3e7)
 82dc965e9294d66f37ffcd2af3f18be03852d2c6 Kha/Tools/windows_x64 (heads/main)
 1a6cf9bbde71efb922356bacdbc89ebc38cf1747 Krom (heads/main)
+6ad27ceee6f8ab209b67c7bada8f6af204a1499d armory (21.06-931-g6ad27ceee)
 827d77dcec12bd70ee05032199300f2ae21194e0 iron (21.06-162-g827d77d)
 947dd3c6d15052734676656bd6d670555f03d568 lib/armory_tools (21.06-15-g947dd3c)
 7f4fea173803f4cdb0b5a12f96f3522e1bdf0cdd lib/haxebullet (20.12-2-g7f4fea1)
 1d5581e0e08fee8586f004a51eab265ae9cbe711 lib/haxerecast (19.12-2-g1d5581e)
 56b10bbf2c4189074dc1f5bcdefa0e55fd3d71ff lib/zui (21.06-70-g56b10bb)
 dd3f8981c42139707f6950ee6a6c66517ed0ed91 nodejs (heads/master)
==============================
| SDK: Modified files        |
==============================
 m Kha
 ? Krom
 M armory
 M armory.py
 ? lib/armory_tools
 m lib/haxebullet
?? .vscode/
?? Pipfile
?? Pipfile.lock
?? api/make.bat
==============================
| Submodules: Modified files |
==============================
Entering 'Kha'
 m Kinc
Entering 'Kha/Backends/Kinc-hxcpp/khacpp'
Entering 'Kha/Kinc'
 M Tools/windows_x64
Entering 'Kha/Kinc/Tools/freebsd_x64'
Entering 'Kha/Kinc/Tools/linux_arm'
Entering 'Kha/Kinc/Tools/linux_arm64'
Entering 'Kha/Kinc/Tools/linux_x64'
Entering 'Kha/Kinc/Tools/macos'
Entering 'Kha/Kinc/Tools/windows_x64'
 M kraffiti.exe
?? kraffiti_old.exe
Entering 'Kha/Tools/freebsd_x64'
Entering 'Kha/Tools/khamake'
Entering 'Kha/Tools/linux_arm'
Entering 'Kha/Tools/linux_arm64'
Entering 'Kha/Tools/linux_x64'
Entering 'Kha/Tools/macos'
Entering 'Kha/Tools/windows_x64'
Entering 'Krom'
?? kinc.dmp
?? stderr.txt
Entering 'armory'
 M Shaders/bloom_pass/bloom_pass.json
 M Sources/armory/renderpath/RenderPathDeferred.hx
 M blender/arm/make.py
 M blender/arm/make_renderpath.py
?? Shaders/bloom_pass/bloom.comp.glsl
?? Shaders/bloom_pass/downsample_pass.frag.glsl
?? Shaders/bloom_pass/upsample_pass.frag.glsl
?? Shaders/std/resample.glsl
?? Sources/armory/renderpath/Downsampler.hx
?? Sources/armory/renderpath/Upsampler.hx
Entering 'iron'
Entering 'lib/armory_tools'
?? mkdocs/make_reference.bat
Entering 'lib/haxebullet'
 M Sources/bullet/Bt.hx
Entering 'lib/haxerecast'
Entering 'lib/zui'
Entering 'nodejs'
Done.
```

Since there is a new button which didn't really fit into the current UI, I slightly changed it by moving the "Help" button somewhere else, I think it looks a bit cleaner now but there's still room for improvement:

![grafik](https://user-images.githubusercontent.com/17685000/204639875-91be1878-0a6e-43f8-9c00-5eb8986a6181.png)

