### PR TITLE
Upgrade workflow actions

### DIFF
--- a/.github/workflows/deploy-api-docs.yml
+++ b/.github/workflows/deploy-api-docs.yml
@@ -10,10 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: krdlab/setup-haxe@v1
+      - uses: krdlab/setup-haxe@v1.2.0
       - name: Setup
         run: haxelib install dox
       - name: Build documentation
@@ -22,7 +22,8 @@ jobs:
           haxe api.hxml -xml build/api.xml -D doc-gen
           haxe dox.hxml
       - name: Deploy gh-pages
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        uses: JamesIves/github-pages-deploy-action@4.4.1
         with:
           branch: gh-pages
           folder: api/pages
+          single-commit: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
-      - uses: krdlab/setup-haxe@v1
+      - uses: krdlab/setup-haxe@v1.2.0
       - name: Build api.xml
         run: |
           cd api


### PR DESCRIPTION
Updates the workflow actions to the latest versions.
This is especially important for actions/checkout, see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Also adds the `single-commit` flag to the deploy-api-docs workflow to **not** store the history in the gh-pages branch.
**Note**: This will also wipe the existing gh-pages history.