### PR TITLE
Fix print_version_info on non git armsdk

### DIFF
--- a/armory.py
+++ b/armory.py
@@ -680,6 +680,11 @@ class ArmAddonPrintVersionInfoButton(bpy.types.Operator):
         if not git_test(self):
             return {"CANCELLED"}
 
+        if not os.path.exists(f'{sdk_path}/.git'):
+            msg=f"{sdk_path}/.git not found"
+            self.report({"ERROR"}, msg)
+            return {"CANCELLED"}
+
         def print_version_info():
             print("==============================")
             print("| SDK: Current commit        |")


### PR DESCRIPTION
Fails if armsdk is missing a .git/ directory otherwise.