### PR TITLE
Fix unix permissions

### DIFF
--- a/armory.py
+++ b/armory.py
@@ -506,53 +506,53 @@ def apply_unix_permissions(sdk):
     """
     if get_os() == 'linux':
         paths=[
-            sdk + "/lib/armory_tools/cmft/cmft-linux64",
-            sdk + "/Krom/Krom",
+            os.path.join(sdk, "lib/armory_tools/cmft/cmft-linux64"),
+            os.path.join(sdk, "Krom/Krom"),
             # NodeJS
-            sdk + "/nodejs/node-linux32",
-            sdk + "/nodejs/node-linux64",
-            sdk + "/nodejs/node-linuxarm",
+            os.path.join(sdk, "nodejs/node-linux32"),
+            os.path.join(sdk, "nodejs/node-linux64"),
+            os.path.join(sdk, "nodejs/node-linuxarm"),
             # Kha tools x64
-            sdk + "/Kha/Tools/linux_x64/haxe",
-            sdk + "/Kha/Tools/linux_x64/lame",
-            sdk + "/Kha/Tools/linux_x64/oggenc",
+            os.path.join(sdk, "Kha/Tools/linux_x64/haxe"),
+            os.path.join(sdk, "Kha/Tools/linux_x64/lame"),
+            os.path.join(sdk, "Kha/Tools/linux_x64/oggenc"),
             # Kha tools arm
-            sdk + "/Kha/Tools/linux_arm/haxe",
-            sdk + "/Kha/Tools/linux_arm/lame",
-            sdk + "/Kha/Tools/linux_arm/oggenc",
+            os.path.join(sdk, "Kha/Tools/linux_arm/haxe"),
+            os.path.join(sdk, "Kha/Tools/linux_arm/lame"),
+            os.path.join(sdk, "Kha/Tools/linux_arm/oggenc"),
             # Kha tools arm64
-            sdk + "/Kha/Tools/linux_arm64/haxe",
-            sdk + "/Kha/Tools/linux_arm64/lame",
-            sdk + "/Kha/Tools/linux_arm64/oggenc",
+            os.path.join(sdk, "Kha/Tools/linux_arm64/haxe"),
+            os.path.join(sdk, "Kha/Tools/linux_arm64/lame"),
+            os.path.join(sdk, "Kha/Tools/linux_arm64/oggenc"),
             # Kinc tools x64
-            sdk + "/Kha/Kinc/Tools/linux_x64/kmake",
-            sdk + "/Kha/Kinc/Tools/linux_x64/kraffiti",
-            sdk + "/Kha/Kinc/Tools/linux_x64/krafix",
+            os.path.join(sdk, "Kha/Kinc/Tools/linux_x64/kmake"),
+            os.path.join(sdk, "Kha/Kinc/Tools/linux_x64/kraffiti"),
+            os.path.join(sdk, "Kha/Kinc/Tools/linux_x64/krafix"),
             # Kinc tools arm
-            sdk + "/Kha/Kinc/Tools/linux_arm/kmake",
-            sdk + "/Kha/Kinc/Tools/linux_arm/kraffiti",
-            sdk + "/Kha/Kinc/Tools/linux_arm/krafix",
+            os.path.join(sdk, "Kha/Kinc/Tools/linux_arm/kmake"),
+            os.path.join(sdk, "Kha/Kinc/Tools/linux_arm/kraffiti"),
+            os.path.join(sdk, "Kha/Kinc/Tools/linux_arm/krafix"),
             # Kinc tools arm64
-            sdk + "/Kha/Kinc/Tools/linux_arm64/kmake",
-            sdk + "/Kha/Kinc/Tools/linux_arm64/kraffiti",
-            sdk + "/Kha/Kinc/Tools/linux_arm64/krafix",
+            os.path.join(sdk, "Kha/Kinc/Tools/linux_arm64/kmake"),
+            os.path.join(sdk, "Kha/Kinc/Tools/linux_arm64/kraffiti"),
+            os.path.join(sdk, "Kha/Kinc/Tools/linux_arm64/krafix"),
         ]
         for path in paths:
             os.chmod(path, 0o777)
 
     if get_os() == 'mac':
         paths=[
-            sdk + "/lib/armory_tools/cmft/cmft-osx",
-            sdk + "/nodejs/node-osx",
-            sdk + "/Krom/Krom.app/Contents/MacOS/Krom",
+            os.path.join(sdk, "lib/armory_tools/cmft/cmft-osx"),
+            os.path.join(sdk, "nodejs/node-osx"),
+            os.path.join(sdk, "Krom/Krom.app/Contents/MacOS/Krom"),
             # Kha tools
-            sdk + "/Kha/Tools/macos/haxe",
-            sdk + "/Kha/Tools/macos/lame",
-            sdk + "/Kha/Tools/macos/oggenc",
+            os.path.join(sdk, "Kha/Tools/macos/haxe"),
+            os.path.join(sdk, "Kha/Tools/macos/lame"),
+            os.path.join(sdk, "Kha/Tools/macos/oggenc"),
             # Kinc tools
-            sdk + "/Kha/Kinc/Tools/macos/kmake",
-            sdk + "/Kha/Kinc/Tools/macos/kraffiti",
-            sdk + "/Kha/Kinc/Tools/macos/krafix",
+            os.path.join(sdk, "Kha/Kinc/Tools/macos/kmake"),
+            os.path.join(sdk, "Kha/Kinc/Tools/macos/kraffiti"),
+            os.path.join(sdk, "Kha/Kinc/Tools/macos/krafix"),
         ]
         for path in paths:
             os.chmod(path, 0o777)

--- a/armory.py
+++ b/armory.py
@@ -516,10 +516,6 @@ def apply_unix_permissions(sdk):
             os.path.join(sdk, "Kha/Tools/linux_x64/haxe"),
             os.path.join(sdk, "Kha/Tools/linux_x64/lame"),
             os.path.join(sdk, "Kha/Tools/linux_x64/oggenc"),
-            # Kha tools arm
-            os.path.join(sdk, "Kha/Tools/linux_arm/haxe"),
-            os.path.join(sdk, "Kha/Tools/linux_arm/lame"),
-            os.path.join(sdk, "Kha/Tools/linux_arm/oggenc"),
             # Kha tools arm64
             os.path.join(sdk, "Kha/Tools/linux_arm64/haxe"),
             os.path.join(sdk, "Kha/Tools/linux_arm64/lame"),


### PR DESCRIPTION
Use `os.path.join()`. Some folders are not present, so removed them from the permissions list.

Thanks to @MoritzBrueckner for the suggestions.