### PR TITLE
Apply symlink option on change

### DIFF
--- a/armory.py
+++ b/armory.py
@@ -301,7 +301,8 @@ class ArmoryAddonPreferences(AddonPreferences):
     use_armory_py_symlink: BoolProperty(
         name="Symlink armory.py", default=False,
         description=("Automatically symlink the registered armory.py with the original armory.py from the SDK for faster"
-                     " development. Warning: this will invalidate the installation if the SDK is removed")
+                     " development. Warning: this will invalidate the installation if the SDK is removed"),
+        update=lambda self, context: update_armory_py(get_sdk_path(context)),
     )
 
     def draw(self, context):


### PR DESCRIPTION
From https://github.com/armory3d/armsdk/issues/65#issuecomment-1630902031:

> Symlinking doesn't update armory.py once it's already installed

Previously, the symlink option was only applied when Armory started (this is also the case if the SDK path changes, Armory gets "restarted" then) or the SDK was downloaded from the user preferences. Now it's also applied directly when the user changes the option.